### PR TITLE
Sort the vacancies in the root page by the newest to the oldest

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -101,7 +101,7 @@ body {
 
         i {
           width: 15px;
-          margin: 0 5px;
+          margin-right: 5px;
           text-align: center;
         }
       }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -100,8 +100,8 @@ body {
         display: block;
 
         i {
-          margin: 0 5px 0 0;
           width: 15px;
+          margin: 0 5px;
           text-align: center;
         }
       }

--- a/app/models/searchs/vacancy.rb
+++ b/app/models/searchs/vacancy.rb
@@ -4,35 +4,38 @@ class Searchs::Vacancy
   end
 
   def list(query = nil, lang = nil)
-    return @repository.all if query.blank?
+    return @repository.recent if query.blank?
 
     lang ||= I18n.locale == :'pt-BR' ? "portuguese" : "english"
 
     sql = %{
-      select
+      SELECT
         id,
         job_title,
         location,
         description,
         company_name,
+        created_at,
         document
-      from
-        (select
+      FROM
+        (SELECT
           id,
           job_title,
           location,
           description,
           company_name,
+          created_at,
           to_tsvector('#{lang}', location) || ' ' ||
           to_tsvector('#{lang}', company_name) || ' ' ||
           to_tsvector('#{lang}', job_title) || ' ' ||
-          to_tsvector('#{lang}', description) as document
-        from vacancies) vacancies
-      where
+          to_tsvector('#{lang}', description) AS document
+        FROM vacancies) vacancies
+      WHERE
         vacancies.document @@ to_tsquery('#{lang}', ?)
+      ORDER BY created_at DESC
     }
 
-    consult = query.split(' ').map { |e| "#{e}:*" }.join('&')
+    consult = query.split(' ').map { |entry| "#{entry}:*" }.join('&')
     @repository.find_by_sql([sql, consult])
   end
 

--- a/app/models/vacancy.rb
+++ b/app/models/vacancy.rb
@@ -1,4 +1,6 @@
 class Vacancy < ApplicationRecord
+  scope :recent, -> { order(created_at: :desc) }
+
   validates :job_title, :location, :description, :how_to_apply, :company_name, :company_url, :company_email,
             presence: true
 

--- a/spec/models/vacancy_spec.rb
+++ b/spec/models/vacancy_spec.rb
@@ -28,4 +28,15 @@ RSpec.describe Vacancy, type: :model do
     vacancy.valid?
     expect(vacancy.company_url).to eq("http://opensanca.com.br")
   end
+
+  describe ".recent" do
+    it "sorts the vacancies by the date from the newest to the oldest" do
+      oldest = create(:vacancy, created_at: 1.year.ago)
+      newest = create(:vacancy, created_at: 5.days.ago)
+
+      result = described_class.recent
+
+      expect(result.first).to eq(newest)
+    end
+  end
 end


### PR DESCRIPTION
This PR will make the home page with the vacancies from the newest to the oldest.

Closes #38 