### PR TITLE
Fix missing entry value on month names on locale

### DIFF
--- a/config/locales/rails.pt-BR.yml
+++ b/config/locales/rails.pt-BR.yml
@@ -9,6 +9,7 @@ pt-BR:
     - Sex
     - Sáb
     abbr_month_names:
+    -
     - Jan
     - Fev
     - Mar
@@ -34,6 +35,7 @@ pt-BR:
       long: "%d de %B de %Y"
       short: "%d de %B"
     month_names:
+    -
     - Janeiro
     - Fevereiro
     - Março


### PR DESCRIPTION
Closes #49. 

Blank value for the entry array was missing