### PR TITLE
Improve new job page title color & location label text for pt-br

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,7 @@ $icon-font-path: "bootstrap-sass/assets/fonts/bootstrap/";
 $error-color: #b94a48;
 $error-background-color: #f2dede;
 
+@import "variables";
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import "bootstrap-sass/assets/stylesheets/bootstrap";
@@ -119,7 +120,7 @@ body {
 
 .page-title {
   text-align: center;
-  color: #f66c35;
+  color: $primary-color;
   margin: 45px;
   font-size: 43px;
   text-shadow: 3px 3px 2px rgba(105, 105, 105, 0.28);

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -119,7 +119,7 @@ body {
 
 .page-title {
   text-align: center;
-  color: #fff;
+  color: #f66c35;
   margin: 45px;
   font-size: 43px;
   text-shadow: 3px 3px 2px rgba(105, 105, 105, 0.28);

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -31,7 +31,7 @@ pt-BR:
       description:     "Descrição da vaga"
       how_to_apply:    "Como os candidatos devem se aplicar para a vaga?"
       job_title:       "Título da vaga"
-      location:        "Local"
+      location:        "Cidade"
       submit_vacancy:  "Enviar vaga"
 
       company_name:  "Nome"


### PR DESCRIPTION
https://github.com/opensanca/opensanca_jobs/issues/73 - Switching the new job page title color to `#ff6f27`. Same orange being currently used for the brand name
https://github.com/opensanca/opensanca_jobs/issues/74 - Changing location label text (pt-br)

![image](https://user-images.githubusercontent.com/2057807/36645053-6577b0d8-1a63-11e8-8005-a67b2ae6cd9c.png)
