### PR TITLE
Remove company's column from vacancy model

### DIFF
--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -32,7 +32,6 @@ class VacanciesController < ApplicationController
   end
 
   def vacancy_params
-    params.require(:vacancy).permit(:job_title, :location, :description, :how_to_apply, :company_name, :company_url,
-                                    :company_email)
+    params.require(:vacancy).permit(:job_title, :location, :description, :how_to_apply)
   end
 end

--- a/db/migrate/20180305210520_remove_company_fields_from_vacancies.rb
+++ b/db/migrate/20180305210520_remove_company_fields_from_vacancies.rb
@@ -1,0 +1,34 @@
+class RemoveCompanyFieldsFromVacancies < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :vacancies, :company_name, :string
+    remove_column :vacancies, :company_url, :string
+    remove_column :vacancies, :company_email, :string
+
+    reversible do |dir|
+      execute <<-SQL
+        DROP TRIGGER vacancies_tsvectorupdate
+        ON vacancies
+      SQL
+
+      dir.up do
+        execute <<-SQL
+          CREATE TRIGGER vacancies_tsvectorupdate BEFORE INSERT OR UPDATE
+          ON vacancies FOR EACH ROW EXECUTE PROCEDURE
+          tsvector_update_trigger(
+            tsv, 'pg_catalog.portuguese', location, job_title, description
+          );
+        SQL
+      end
+
+      dir.down do
+        execute <<-SQL
+          CREATE TRIGGER vacancies_tsvectorupdate BEFORE INSERT OR UPDATE
+          ON vacancies FOR EACH ROW EXECUTE PROCEDURE
+          tsvector_update_trigger(
+            tsv, 'pg_catalog.portuguese', location, company_name, job_title, description
+          );
+        SQL
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180221233924) do
+ActiveRecord::Schema.define(version: 20180305210520) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,18 +41,13 @@ ActiveRecord::Schema.define(version: 20180221233924) do
     t.string "job_title"
     t.string "location"
     t.text "description"
-    t.string "company_name"
-    t.string "company_url"
-    t.string "company_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "how_to_apply", null: false
     t.string "slug"
     t.tsvector "tsv"
     t.integer "company_id"
-    t.index ["company_email"], name: "index_vacancies_on_company_email"
     t.index ["company_id"], name: "index_vacancies_on_company_id"
-    t.index ["company_url"], name: "index_vacancies_on_company_url"
     t.index ["location"], name: "index_vacancies_on_location"
     t.index ["slug"], name: "index_vacancies_on_slug", unique: true
     t.index ["tsv"], name: "index_vacancies_on_tsv", using: :gin


### PR DESCRIPTION
After #63, we don't need this fields anymore, since they are saved on
the Company model.

Closes #78 