### PR TITLE
Restrict Sidekiq dashboard on production

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,13 @@
 require 'sidekiq/web'
 
 Rails.application.routes.draw do
+  Sidekiq::Web.use Rack::Auth::Basic do |username, password|
+    ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV['SIDEKIQ_USERNAME'])) &
+      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV['SIDEKIQ_PASSWORD']))
+  end if Rails.env.production?
+
+  mount Sidekiq::Web => '/sidekiq'
+
   resources :passwords, controller: 'clearance/passwords', only: %i[create new]
   resource :session, controller: 'clearance/sessions', only: [:create]
 
@@ -15,8 +22,6 @@ Rails.application.routes.draw do
   get '/sign_in' => 'clearance/sessions#new', as: 'sign_in'
   delete '/sign_out' => 'clearance/sessions#destroy', as: 'sign_out'
   get '/sign_up' => 'clearance/users#new', as: 'sign_up'
-
-  mount Sidekiq::Web => '/sidekiq'
 
   resources :vacancies, except: %i[edit update destroy]
 


### PR DESCRIPTION
Currently, our production's sidekiq dashboard is open. This PR changes this behavior to protect it using 2 environment variables. SIDEKIQ_USERNAME and SIDEKIQ_PASSWORD

Closes #80 