### PR TITLE
Add feature tests for the registration flow

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development, :test do
   gem 'factory_girl_rails'
   gem 'fuubar'
   gem 'rspec-rails'
+  gem 'selenium-webdriver'
   gem 'shoulda-matchers'
 
   # environment variables

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (>= 2.0, < 4.0)
+    childprocess (0.8.0)
+      ffi (~> 1.0, >= 1.0.11)
     clearance (1.16.1)
       bcrypt
       email_validator (~> 1.4)
@@ -211,6 +213,7 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
+    rubyzip (1.2.1)
     sass (3.4.24)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -218,6 +221,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    selenium-webdriver (3.9.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sexp_processor (4.10.1)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
@@ -295,6 +301,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sass-rails (~> 5.0)
+  selenium-webdriver
   shoulda-matchers
   sidekiq
   slack-notifier

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,4 +1,4 @@
-<h1>Cadastro de usuário</h1>
+<h1><%= t(".title") %></h1>
 
 <%= form.text_field :email, autofocus: true, class: 'field', type: 'email', placeholder: User.human_attribute_name('email') %>
 
@@ -6,9 +6,9 @@
 
 <br/>
 
-<h1>Dados da Empresa:</h1>
+<h1><%= t(".company_data") %></h1>
 
 <%= form.fields_for :company, @user.company || @user.build_company do |company_form| %>
-  <%= company_form.text_field :name, class: 'field', placeholder: 'Nome da empresa'%>
-  <%= company_form.text_field :url,  class: 'field', placeholder: 'URL da empresa'%>
+  <%= company_form.text_field :name, class: 'field', placeholder: Company.human_attribute_name(:name) %>
+  <%= company_form.text_field :url,  class: 'field', placeholder: Company.human_attribute_name(:url) %>
 <% end %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -43,4 +43,6 @@ Rails.application.configure do
   Rails.application.routes.default_url_options[:host] = 'localhost:3000'
 
   config.middleware.use Clearance::BackDoor
+
+  config.i18n.default_locale = :en
 end

--- a/config/initializers/locale.rb
+++ b/config/initializers/locale.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 Rails.application.config.time_zone = 'Brasilia'
-Rails.application.config.i18n.default_locale = :'pt-BR'
+Rails.application.config.i18n.default_locale ||= :'pt-BR'

--- a/config/locales/activerecord.en.yml
+++ b/config/locales/activerecord.en.yml
@@ -1,0 +1,12 @@
+en:
+  activerecord:
+    models:
+      user: User
+    attributes:
+      user:
+        email: E-mail
+        password: Password
+        company: Company
+      company:
+        name: Company name
+        url: Company website

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,12 @@ en:
       company_email: "E-mail"
     create:
       success: "Vacancy posted with success."
+    search: "Search"
+
+  users:
+    form:
+      company_data: 'Company information'
+      title: 'User Registration'
 
   helpers:
     submit:

--- a/config/locales/mailers.en.yml
+++ b/config/locales/mailers.en.yml
@@ -1,0 +1,8 @@
+en:
+  user_mailer:
+    welcome_email:
+      subject: Welcome to OpenJobs!
+      welcome_message: Welcome to OpenJobs, %{company}
+      intro: You did post your job on Openjobs sometime ago. Today we are creating the company login area, so it will help you publish your next jobs and manage them.
+      finish_setup_message_html: To finish your account setup, you should visit <a href="%{url}">this link</a> to setup your password.
+      thanks_message: Thanks for using OpenJobs ❤️

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -41,6 +41,11 @@ pt-BR:
       success: "Vaga enviada com sucesso."
     search: "Pesquisar"
 
+  users:
+    form:
+      company_data: 'Dados da Empresa'
+      title: 'Cadastro de usuário'
+
   helpers:
     submit:
       vacancy:

--- a/spec/features/registration_spec.rb
+++ b/spec/features/registration_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Registration', type: :feature do
+  scenario 'user registration and sign in' do
+    visit root_path
+
+    click_on 'Advertise for free'
+    click_on 'Sign up'
+
+    fill_in placeholder: 'E-mail',   with: 'vader@galacticempire.com'
+    fill_in placeholder: 'Password', with: 'deathstar'
+
+    fill_in placeholder: 'Company name',    with: 'Galactic Empire'
+    fill_in placeholder: 'Company website', with: 'http://galacticempire.com'
+
+    click_on 'Sign up'
+
+    expect(page).to have_text 'Submit your vacancy'
+    expect(page).to have_text 'Sign Out'
+
+    # Try to login with the same informations
+
+    click_on 'Sign Out'
+
+    expect(page).to have_text 'Sign in'
+
+    fill_in placeholder: 'E-mail',   with: 'vader@galacticempire.com'
+    fill_in placeholder: 'Password', with: 'deathstar'
+
+    click_on 'Sign in'
+
+    expect(page).to have_text 'Sign Out'
+  end
+
+  scenario 'registering with an existing email' do
+    create(:user, email: 'vader@galacticempire.com')
+
+    visit root_path
+
+    click_on 'Advertise for free'
+    click_on 'Sign up'
+
+    fill_in placeholder: 'E-mail',   with: 'vader@galacticempire.com'
+    fill_in placeholder: 'Password', with: 'deathstar'
+
+    fill_in placeholder: 'Company name',    with: 'Galactic Empire'
+    fill_in placeholder: 'Company website', with: 'http://galacticempire.com'
+
+    click_on 'Sign up'
+
+    expect(page).to have_text 'E-mail has already been taken'
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -10,7 +10,7 @@ describe UserMailer, type: :mailer do
     let(:email) { described_class.welcome_email(user) }
 
     it 'renders the headers' do
-      expect(email.subject).to eq('Bem vindo ao OpenJobs!')
+      expect(email.subject).to eq('Welcome to OpenJobs!')
       expect(email.to).to eq([user.email])
       expect(email.from).to eq(['no-reply@openjobs.me'])
     end
@@ -18,7 +18,7 @@ describe UserMailer, type: :mailer do
     context 'body' do
       subject { email.body.encoded }
 
-      it { is_expected.to match('Bem vindo ao OpenJobs, Galactic Empire') }
+      it { is_expected.to match('Welcome to OpenJobs, Galactic Empire') }
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,6 +23,8 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
 end
 
+Capybara.default_driver = ENV.fetch('CAPYBARA_DRIVER') { 'rack_test' }.to_sym
+
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :rspec


### PR DESCRIPTION
This PR will add the missing feature tests for the registration flow. Also, it will configure capybara to use English locale. This way we can use English words on the tests instead of relying on I18n.