### PR TITLE
Use the right style on the error box

### DIFF
--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,7 +2,7 @@
   <div class="login-container">
     <div class="sign-box">
       <% if @user.errors.any? %>
-        <ul class="error_list">
+        <ul class="error-list">
           <% @user.errors.full_messages.each do |msg| %>
             <li class="alert-error">
               <%= msg %>


### PR DESCRIPTION
We have an UI problem now with the error list for signup:
![image](https://user-images.githubusercontent.com/771411/37004445-2c58eac2-20af-11e8-8a9b-582647d95b34.png)

It is not using the right classes.

This PR will fix it:
![image](https://user-images.githubusercontent.com/771411/37004476-462a3b90-20af-11e8-8f95-e3e7bc3ca574.png)


