### PR TITLE
Fix intermitent test failure on index page feature spec

### DIFF
--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.feature 'Visit index page', type: :feature do
   scenario 'lists all vacancies in the index page' do
     vacancy1, vacancy2, vacancy3 = create_list(:vacancy, 3)
-    old_vacancy = create(:vacancy, created_at: (Vacancy::MAX_VALID_PERIOD + 1.day).ago)
+    old_vacancy = create(:vacancy, job_title: 'An old job', created_at: (Vacancy::MAX_VALID_PERIOD + 1.day).ago)
 
     visit root_path
 


### PR DESCRIPTION
Since we are using faker to generate data, it sometimes generate
the same job title for both new job and old job, and we rely on this
two titles to check if the test is valid or not and it fails.

This commit adds a static text to the old job created in the spec and
fix the intermitent failure.

Closes #92