### PR TITLE
Handle company custom subdomain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@
 class ApplicationController < ActionController::Base
   include Clearance::Controller
   protect_from_forgery with: :exception
-  before_action :check_company_subdomain
+  before_action :filter_by_company
 
   private
 
@@ -12,12 +12,19 @@ class ApplicationController < ActionController::Base
     current_user.company
   end
 
-  def check_company_subdomain
+  def filter_by_company
+    if company_subdomain?
+      @filter_by = matching_company || not_found
+    end
+  end
+
+  def company_subdomain?
     subdomain = request.subdomain
-    return if subdomain.empty? || subdomain == 'www'
-    matching_company = Company.find_by domain: subdomain
-    not_found unless matching_company
-    @filtered_by = matching_company
+    !subdomain.empty? && subdomain != 'www'
+  end
+
+  def matching_company
+    Company.find_by(domain: request.subdomain)
   end
 
   def not_found

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,23 @@
 class ApplicationController < ActionController::Base
   include Clearance::Controller
   protect_from_forgery with: :exception
+  before_action :check_company_subdomain
 
   private
 
   def current_company
     current_user.company
+  end
+
+  def check_company_subdomain
+    subdomain = request.subdomain
+    return if subdomain.empty? || subdomain == 'www'
+    matching_company = Company.find_by domain: subdomain
+    not_found unless matching_company
+    @filtered_by = matching_company
+  end
+
+  def not_found
+    raise ActionController::RoutingError, 'Not Found'
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@
 class ApplicationController < ActionController::Base
   include Clearance::Controller
   protect_from_forgery with: :exception
-  before_action :filter_by_company
+  before_action :filter_by_company, if: :company_subdomain?
 
   private
 
@@ -13,9 +13,7 @@ class ApplicationController < ActionController::Base
   end
 
   def filter_by_company
-    if company_subdomain?
-      @filter_by = matching_company || not_found
-    end
+    @filter_by = matching_company || not_found
   end
 
   def company_subdomain?

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -7,7 +7,7 @@ class VacanciesController < ApplicationController
 
   def index
     @search = params[:search]
-    @vacancies = Searchs::Vacancy.list(@search)
+    @vacancies = Searchs::Vacancy.list(@search, @filtered_by)
   end
 
   def new

--- a/app/controllers/vacancies_controller.rb
+++ b/app/controllers/vacancies_controller.rb
@@ -7,7 +7,7 @@ class VacanciesController < ApplicationController
 
   def index
     @search = params[:search]
-    @vacancies = Searchs::Vacancy.list(@search, @filtered_by)
+    @vacancies = Searchs::Vacancy.list(@search, @filter_by)
   end
 
   def new

--- a/app/models/searchs/vacancy.rb
+++ b/app/models/searchs/vacancy.rb
@@ -7,16 +7,13 @@ module Searchs
     end
 
     def list(query = nil, company = nil)
-      if query.blank?
-        vacancies = @repository.recent
-      else
-        query = query.split.map { |entry| "#{entry}:*" }.join(' & ')
-        vacancies = @repository.where(<<~SQL, query: query)
-          tsv @@ to_tsquery('portuguese', :query) OR company_tsv @@ to_tsquery('portuguese', :query)
-        SQL
-      end
-      vacancies = vacancies.where company: company if company
-      vacancies
+      scope = company.present? ? @repository.where(company: company) : @repository
+      return scope.recent if query.blank?
+
+      query = query.split.map { |entry| "#{entry}:*" }.join(' & ')
+      scope.where(<<~SQL, query: query)
+        tsv @@ to_tsquery('portuguese', :query) OR company_tsv @@ to_tsquery('portuguese', :query)
+      SQL
     end
 
     def self.list(query = nil, company = nil)

--- a/app/models/searchs/vacancy.rb
+++ b/app/models/searchs/vacancy.rb
@@ -6,18 +6,21 @@ module Searchs
       @repository = repository
     end
 
-    def list(query = nil)
-      return @repository.recent if query.blank?
-
-      query = query.split.map { |entry| "#{entry}:*" }.join(' & ')
-
-      @repository.where(<<~SQL, query: query)
-        tsv @@ to_tsquery('portuguese', :query) OR company_tsv @@ to_tsquery('portuguese', :query)
-      SQL
+    def list(query = nil, company = nil)
+      if query.blank?
+        vacancies = @repository.recent
+      else
+        query = query.split.map { |entry| "#{entry}:*" }.join(' & ')
+        vacancies = @repository.where(<<~SQL, query: query)
+          tsv @@ to_tsquery('portuguese', :query) OR company_tsv @@ to_tsquery('portuguese', :query)
+        SQL
+      end
+      vacancies = vacancies.where company: company if company
+      vacancies
     end
 
-    def self.list(query = nil)
-      new.list(query)
+    def self.list(query = nil, company = nil)
+      new.list(query, company)
     end
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,13 +3,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "0fec207730e6e49e3a26072db4ac2c9340f15edc89c34369d217312b131b0f30",
+      "fingerprint": "43d057d354420a5510904cd24ce57bfbb5c7adc5fd89cd7a4d238e9a5455ad9d",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/vacancies/index.html.erb",
-      "line": 18,
-      "link": "https://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => Searchs::Vacancy.list(params[:search]), {})",
+      "line": 17,
+      "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => Searchs::Vacancy.list(params[:search], @filter_by), {})",
       "render_path": [{"type":"controller","class":"VacanciesController","method":"index","line":11,"file":"app/controllers/vacancies_controller.rb"}],
       "location": {
         "type": "template",

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -24,4 +24,19 @@ RSpec.feature 'Visit index page', type: :feature do
 
     expect(page).to have_content(I18n.t('vacancies.index.no_vacancies'))
   end
+
+  context 'with subdomain' do
+    within_subdomain 'galacticempire' do
+      scenario 'lists only the company\'s vacancies' do
+        company = create(:company, domain: 'galacticempire')
+        other_company = create(:company)
+        vacancy = create(:vacancy, company: company, job_title: 'Chief Universal Officer')
+        other_vacancy = create(:vacancy, company: other_company, job_title: 'Wormhole Analyst')
+
+        visit root_path
+        expect(page).to have_content(vacancy.job_title)
+        expect(page).not_to have_content(other_vacancy.job_title)
+      end
+    end
+  end
 end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature 'Visit index page', type: :feature do
 
   context 'with subdomain' do
     within_subdomain 'galacticempire' do
-      scenario 'lists only the company\'s vacancies' do
+      scenario "lists only the company's vacancies" do
         company = create(:company, domain: 'galacticempire')
         other_company = create(:company)
         vacancy = create(:vacancy, company: company, job_title: 'Chief Universal Officer')

--- a/spec/models/searchs/vacancy_spec.rb
+++ b/spec/models/searchs/vacancy_spec.rb
@@ -43,7 +43,7 @@ describe Searchs::Vacancy, type: :search do
       let(:other_company)  { create(:company, name: 'Evil Company') }
       let!(:vacancy)       { create(:vacancy, job_title: 'programador ruby', company: company) }
       let!(:other_vacancy) { create(:vacancy, job_title: 'programador java', company: other_company) }
-      it 'returns only company\'s vacancies' do
+      it "returns only company's vacancies" do
         expect(Searchs::Vacancy.list(nil, company)).to eq [vacancy]
       end
     end

--- a/spec/models/searchs/vacancy_spec.rb
+++ b/spec/models/searchs/vacancy_spec.rb
@@ -37,5 +37,15 @@ describe Searchs::Vacancy, type: :search do
         it { is_expected.to eq([vacancy]) }
       end
     end
+
+    context 'with company parameter' do
+      let(:company)        { create(:company, name: 'Galactic Empire') }
+      let(:other_company)  { create(:company, name: 'Evil Company') }
+      let!(:vacancy)       { create(:vacancy, job_title: 'programador ruby', company: company) }
+      let!(:other_vacancy) { create(:vacancy, job_title: 'programador java', company: other_company) }
+      it 'returns only company\'s vacancies' do
+        expect(Searchs::Vacancy.list(nil, company)).to eq [vacancy]
+      end
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,14 @@ require 'faker'
 
 ActiveRecord::Migration.maintain_test_schema!
 
+module FeatureSubdomainHelpers
+  def within_subdomain(subdomain)
+    before { Capybara.app_host = "http://#{subdomain}.example.com" }
+    after  { Capybara.app_host = 'http://example.com' }
+    yield
+  end
+end
+
 RSpec.configure do |config|
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
@@ -29,6 +37,8 @@ RSpec.configure do |config|
     Rails.application.config.action_dispatch.show_exceptions = false
     Rails.application.config.consider_all_requests_local = true
   end
+
+  config.extend FeatureSubdomainHelpers, type: :feature
 end
 
 Capybara.default_driver = ENV.fetch('CAPYBARA_DRIVER') { 'rack_test' }.to_sym


### PR DESCRIPTION
If the request contains a non-empty subdomain, try to find a company
with the corresponding custom domain. If not found, raises an
appropriate error response. If found, stores the company record in the
controller instance so it is available to be used by views and
controller actions.

If requesting the vacancies list (index page) and there is a custom
domain, use the company to filter the vacancies list.